### PR TITLE
fix: Change focus-in event to blur to keep autocomplete open

### DIFF
--- a/src/cn-tags-input.js
+++ b/src/cn-tags-input.js
@@ -455,6 +455,10 @@
 
                   ngModelCtrl.$setValidity('leftoverText', options.allowLeftoverText ? true : !scope.newTag.text);
                 }
+              
+                // Reset newTag
+                scope.newTag.text = '';
+                scope.newTag.invalid = null;
               });
 
           scope.newTag = {text: '', invalid: null};
@@ -1052,7 +1056,6 @@
           scope.suggestionList = suggestionList;
 
           scope.addSuggestion = function(e) {
-            //console.log('addSuggestion:', e);
             e.preventDefault();
 
             //selectAll(e.target);
@@ -1221,17 +1224,17 @@
             if(suggestionList.visible) {
               // if autocomplete option was selected, or click/focus triggered outside of directive
               if(($(e.target).closest('.suggestion').length || !$(e.target).closest(element[0]).length) &&
-                  !(e.type === 'focusin' && !/^(input|select|textarea|button|a)$/i.test(e.target.tagName))) {
+                  !(e.type === 'blur' && !/^(input|select|textarea|button|a)$/i.test(e.target.tagName))) {
                 suggestionList.reset();
                 if(!/apply|digest/.test(scope.$root.$$phase)) scope.$apply();
               }
             }
           };
 
-          $document.on('click focusin', documentClick);
+          $document.on('click blur', documentClick);
 
           scope.$on('$destroy', function() {
-            $document.off('click focusin', documentClick);
+            $document.off('click blur', documentClick);
           });
         }
       };


### PR DESCRIPTION
fix: Reset tag model on blur event

We were previously using the focusin event to reset the suggested
collection. However, focusin will fire if any parent element in the dom
tree receives focus. Thus, nested forms were closing on click because
they were receiving unexpected focusin events. Also, we are now clearing
the model on blur which provides a better user experience.

FBCM-482